### PR TITLE
Fix jittering on scroll

### DIFF
--- a/scss/facepunch/header.scss
+++ b/scss/facepunch/header.scss
@@ -6,6 +6,7 @@
   &.fixed {
     header {
       padding-top: 0;
+      margin-top: 2rem;
       &:before {
         height: 55px;
         opacity: 1;


### PR DESCRIPTION
Currently, when you scroll a small bit on the facepunch forums, the forums start aggressively jittering. It's not much of a problem, but the mere thought of this bug existing bothered me, so I decided to fix it.

The reason this happens is javascript adding a class to the css when it detects a scroll over 50, but this class affects the overall scroll of the page, so it snaps back under 50, and it goes back in forth.
I simply added a margin-top to compensate for the page scroll change, and the problem is fixed.

**Before**
https://user-images.githubusercontent.com/53242610/110530932-e2d5f800-8112-11eb-9b49-ebe5484d4457.mp4

**After**
https://user-images.githubusercontent.com/53242610/110531063-0600a780-8113-11eb-8ec3-ec4f99b686a6.mp4