### PR TITLE
Fix "Page Not Found" Page Transparency Issue

### DIFF
--- a/scss/facepunch/general.scss
+++ b/scss/facepunch/general.scss
@@ -62,3 +62,9 @@ a:hover {
 .post-notice.new-user {
   display: none;
 }
+
+// Display opaque background against image on "page not found" page
+.not-found-container {
+  border-radius: $radius;
+  background-color: var(--secondary);
+}


### PR DESCRIPTION
The "page not found" page is very hard to look at and read because of the background image over the main site. This should fix that by adding a background color and style similar to categories.

**Before:** https://i.imgur.com/BWis9DN.png
**After:** https://i.imgur.com/Xq4CWfP.png
