### PR TITLE
Add Padding to .presence-users

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -52,3 +52,7 @@
 {
   display: none;
 }
+
+.presence-users {
+  padding: 10px;
+}


### PR DESCRIPTION
I thought it would fit here, this will add an 10 pixel padding to the bar you see when someone is typing in the post.

before: 
![unknown](https://user-images.githubusercontent.com/19864478/115957916-761d8e00-a505-11eb-87b4-f42d22f219c9.png)
after:
![image](https://user-images.githubusercontent.com/19864478/115957922-80d82300-a505-11eb-88ee-bd83327d3d63.png)
