### PR TITLE
Add margin to presence avatars

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -56,3 +56,7 @@
 .presence-users {
   padding: 10px;
 }
+
+.presence-avatars {
+  margin-right: 2px;
+}


### PR DESCRIPTION
I Also noticed that the Avatars dont have a space in between.
This will add 2 pixel of space (on the right side)  to make it feel better when multiple are typing (cant show an example as there isnt much going on in the forums right now)

This could also be negative to make it "stack"