### PR TITLE
Fix displaying a locked+pinned thread

### DIFF
--- a/scss/facepunch/category.scss
+++ b/scss/facepunch/category.scss
@@ -142,5 +142,12 @@ body {
         }
       }
     }
+    
+    .topic-statuses {
+      padding: 0 1px;
+      display: flex;
+      flex-direction: row;
+    }
+    
   }
 }


### PR DESCRIPTION
Fix the display of both the lock and pin symbols next to a thread in recent, so that they are next to each other instead of one above the other.